### PR TITLE
Don't crash when icon not set during XML inflation

### DIFF
--- a/listitemview/src/main/java/com/lucasurbas/listitemview/ListItemView.java
+++ b/listitemview/src/main/java/com/lucasurbas/listitemview/ListItemView.java
@@ -14,7 +14,6 @@ import android.support.annotation.MenuRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
-import android.support.v4.content.ContextCompat;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v7.content.res.AppCompatResources;
 import android.support.v7.view.menu.MenuBuilder;
@@ -226,8 +225,10 @@ public class ListItemView extends FrameLayout {
             mKeyline = a.getDimensionPixelSize(R.styleable.ListItemView_liv_keyline, mKeyline);
             mForceKeyline = a.getBoolean(R.styleable.ListItemView_liv_forceKeyline, false);
 
-            int iconDrawableResId = a.getResourceId(R.styleable.ListItemView_liv_icon, -1);
-            mIconDrawable = AppCompatResources.getDrawable(getContext(), iconDrawableResId);
+            int iconDrawableResId = a.getResourceId(R.styleable.ListItemView_liv_icon, NULL);
+            if (iconDrawableResId != NULL) {
+                mIconDrawable = AppCompatResources.getDrawable(getContext(), iconDrawableResId);
+            }
 
             mIconColor = a.getColor(R.styleable.ListItemView_liv_iconColor, Color.TRANSPARENT);
             mCircularIconColor = a.getColor(R.styleable.ListItemView_liv_circularIconColor,
@@ -591,7 +592,7 @@ public class ListItemView extends FrameLayout {
     public void setIconResId(@DrawableRes final int iconResId) {
         mIconResId = iconResId;
         setIconDrawable(
-                mIconResId != NULL ? ContextCompat.getDrawable(getContext(), mIconResId) : null);
+                mIconResId != NULL ? AppCompatResources.getDrawable(getContext(), mIconResId) : null);
     }
 
     /**


### PR DESCRIPTION
There is a small error in the latest `1.0.4` release. Inflation via XML crashes when no icon resource is set.

Also use I change  `ContextCompat.getDrawable` to `AppCompatResources.getDrawable` everywhere

```
Caused by: android.content.res.Resources$NotFoundException: Resource ID #0xffffffff
at android.content.res.ResourcesImpl.getValue(ResourcesImpl.java:190)
at android.content.res.Resources.getValue(Resources.java:1290)
at android.support.v7.widget.AppCompatDrawableManager.createDrawableIfNeeded(AppCompatDrawableManager.java:236)
at android.support.v7.widget.AppCompatDrawableManager.getDrawable(AppCompatDrawableManager.java:199)
at android.support.v7.widget.AppCompatDrawableManager.getDrawable(AppCompatDrawableManager.java:190)
at android.support.v7.content.res.AppCompatResources.getDrawable(AppCompatResources.java:100)
at com.lucasurbas.listitemview.ListItemView.applyAttrs(ListItemView.java:230)
at com.lucasurbas.listitemview.ListItemView.init(ListItemView.java:197)
at com.lucasurbas.listitemview.ListItemView.<init>(ListItemView.java:172)
```

```
is crashing:
                <com.lucasurbas.listitemview.ListItemView
                    android:layout_width="match_parent"
                    android:layout_height="wrap_content"
                    app:liv_subtitle="World"
                    app:liv_title="Hello" />

workaround:
                <com.lucasurbas.listitemview.ListItemView
                    android:layout_width="match_parent"
                    android:layout_height="wrap_content"
                    app:liv_subtitle="World"
                    app:liv_title="Hello"
                    app:liv_icon="@android:color/transparent" />
```