### PR TITLE
Removed unneeded application properties

### DIFF
--- a/listitemview/src/main/AndroidManifest.xml
+++ b/listitemview/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.lucasurbas.listitemview">
+<manifest package="com.lucasurbas.listitemview">
 
-    <application android:supportsRtl="true" />
+    <application />
 
 </manifest>

--- a/listitemview/src/main/AndroidManifest.xml
+++ b/listitemview/src/main/AndroidManifest.xml
@@ -1,11 +1,6 @@
-<manifest package="com.lucasurbas.listitemview"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.lucasurbas.listitemview">
 
-    xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <application android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+    <application android:supportsRtl="true" />
 
 </manifest>

--- a/listitemview/src/main/res/values/strings.xml
+++ b/listitemview/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Library</string>
-</resources>


### PR DESCRIPTION
Self explanatory: before these changes if you want to disable backups in your app, this library forces you to add `tools:replace="android:allowBackup"` to the app's manifest